### PR TITLE
Send JSON with values in Google Analytics Events

### DIFF
--- a/source/Firebase_gml/extensions/YYFirebaseAnalytics/AndroidSource/Java/YYFirebaseAnalytics.java
+++ b/source/Firebase_gml/extensions/YYFirebaseAnalytics/AndroidSource/Java/YYFirebaseAnalytics.java
@@ -8,6 +8,8 @@ import android.app.Activity;
 import android.os.Bundle;
 
 import org.json.JSONObject;
+import org.json.JSONArray;
+
 import java.lang.Exception;
 
 import com.google.firebase.analytics.FirebaseAnalytics;
@@ -99,13 +101,25 @@ public class YYFirebaseAnalytics extends RunnerSocial
 				Object aObj = jsonObject.get(key);
 				if(aObj instanceof String)
 					bundle.putString(key,jsonObject.getString(key));
-				else
+				else if (aObj instanceof JSONArray){
+					JSONArray jsonArray = jsonObject.getJSONArray(key);
+					for(int i = 0; i < jsonArray.length(); i++)
+					{
+						JSONObject obj = jsonArray.getJSONObject(i);
+						
+						Bundle itemBundle = new Bundle();
+						itemBundle.putString("item_id", obj.getString("item_id"));
+						itemBundle.putString("item_name", obj.getString("item_name"));
+						bundle.putParcelableArray(key, new Bundle[] {itemBundle});
+					}
+				} else
 					bundle.putDouble(key,jsonObject.getDouble(key));
 			}
 			return bundle;
 		} 
 		catch (Exception e) 
 		{
+					Log.e("yoyo", "jsonStringToBundle Exception: " + e.getMessage(), e);
 		}
 		return new Bundle();
 	}


### PR DESCRIPTION
It happened to me that when trying to send a struct or json of parameters to try to configure the "PURCHASE" event of Google Analytics, so that they enable the predictions, I found that it allowed me to send only strings and integers, so, I propose a solution that I am currently using in production in my games.

This allows send the information that Firebase requests (ITEMS) to be able to make prediction in the purchases in the application, as well as the possibility of sending multiple custom parameters.

![image](https://github.com/YoYoGames/GMEXT-Firebase/assets/14205306/f6affb04-02c0-4a4e-9102-fdce768f40a3)
![image](https://github.com/YoYoGames/GMEXT-Firebase/assets/14205306/e39a6a0e-5f7a-4660-9616-570fcb29ff7a)

I tested it in production and with Debug View and it works correctly, and I don't get any errors about its implementation, but just in case test it a bit.

One of my games:
https://play.google.com/store/apps/details?id=com.luxetecnogames.mymusichero

Doc: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#PURCHASE

---

On the other hand, I have published these games for years, I have been using Game Maker for about 8-10 years and the last 7 years I have been generating about 600-1500 dollars a month in advertising with games on Google Play, I have advanced knowledge in PHP and Javascript (front/back) | Typescript | Java (A little less), etc.
I love Game Maker, count on me for whatever, if you want to access Crashlytics statistics | Ad Mob | Google Play etc, I would be honored, I recently included Firebase Remote Config.

Thanks for everything.

(Sorry for my English, it's not very good)