### PR TITLE
Cleanup: Improve platform credential folder handling in pre_build_step.sh

### DIFF
--- a/source/Firebase_gml/extensions/FirebaseSetup/pre_build_step.sh
+++ b/source/Firebase_gml/extensions/FirebaseSetup/pre_build_step.sh
@@ -7,22 +7,40 @@ source "$(dirname "$0")/scriptUtils.sh"
 # ######################################################################################
 # Script Functions
 
+# setupAndroid: Copies the Android Firebase credentials JSON file into the project's
+# AndroidSource/ProjectFiles directory. If the destination directory doesn't exist, it
+# will be created. If a file with the same name exists, it will be deleted before
+# creating the directory.
 setupAndroid() {
     echo "Copying Android Firebase credentials into your project."
     optionGetValue "jsonFile" CREDENTIAL_FILE
 
     # Resolve the credentials file path and copy it to the Android ProjectFiles folder
     pathResolveExisting "$YYprojectDir" "$CREDENTIAL_FILE" FILE_PATH
-    itemCopyTo "${FILE_PATH}" "$1/AndroidSource/ProjectFiles"
+    DEST_DIR="$1/AndroidSource/ProjectFiles"
+    if [ -f "$DEST_DIR" ]; then
+        rm -f "$DEST_DIR"
+    fi
+    mkdir -p "$DEST_DIR"
+    itemCopyTo "${FILE_PATH}" "$DEST_DIR/"
 }
 
+# setupiOS: Copies the iOS Firebase credentials plist file into the project's
+# iOSProjectFiles directory. If the destination directory doesn't exist, it will be
+# created. If a file with the same name exists, it will be deleted before creating the
+# directory.
 setupiOS() {
     echo "Copying iOS Firebase credentials into your project."
     optionGetValue "plistFile" CREDENTIAL_FILE
 
     # Resolve the credentials file path and copy it to the iOS ProjectFiles folder
     pathResolveExisting "$YYprojectDir" "$CREDENTIAL_FILE" FILE_PATH
-    itemCopyTo "${FILE_PATH}" "$1/iOSProjectFiles"
+    DEST_DIR="$1/iOSProjectFiles"
+    if [ -f "$DEST_DIR" ]; then
+        rm -f "$DEST_DIR"
+    fi
+    mkdir -p "$DEST_DIR"
+    itemCopyTo "${FILE_PATH}" "$DEST_DIR/"
 }
 
 setupHTML5() {
@@ -42,11 +60,17 @@ optionGetValue "versionDev" RUNTIME_VERSION_DEV
 optionGetValue "versionLTS" RUNTIME_VERSION_LTS
 
 # Version lock
-versionLockCheck "$YYruntimeVersion" $RUNTIME_VERSION_STABLE $RUNTIME_VERSION_BETA $RUNTIME_VERSION_RED $RUNTIME_VERSION_LTS
+versionLockCheck "$YYruntimeVersion" \
+    $RUNTIME_VERSION_STABLE \
+    $RUNTIME_VERSION_BETA \
+    $RUNTIME_VERSION_RED \
+    $RUNTIME_VERSION_LTS
 
-# Delete pre-existing credential files
-itemDelete "$(dirname "$0")/AndroidSource/ProjectFiles/"
-itemDelete "$(dirname "$0")/iOSProjectFiles/"
+
+rm -rf "$(dirname "$0")/AndroidSource/ProjectFiles/"*
+rm -rf "$(dirname "$0")/iOSProjectFiles/"*
+
+mkdir -p "$(dirname "$0")/AndroidSource/ProjectFiles"
+mkdir -p "$(dirname "$0")/iOSProjectFiles"
 
 setup$YYPLATFORM_name "$(dirname "$0")"
-


### PR DESCRIPTION
Previous version might fail copying the credentials, and cause error on run. Cause: 

- Destination folder did not exist yet, will cause the credential copied as file instead of into the folder
- A file with the same name exists, which caused fail to copy into a folder with same name

This fix do this instead:
- Delete file with the same name as target folder
- Check folder existence, creating it otherwise, before continuing with the copy
- Issue #64 