### PR TITLE
Fixed FirebaseAnalytics_SetUserProperty

### DIFF
--- a/source/Firebase_gml/extensions/YYFirebaseAnalytics/iOSSource/YYFirebaseAnalytics.mm
+++ b/source/Firebase_gml/extensions/YYFirebaseAnalytics/iOSSource/YYFirebaseAnalytics.mm
@@ -107,13 +107,13 @@ static const double kFirebaseAnalyticsErrorInvalidParameters = -1.0;
     return kFirebaseAnalyticsSuccess;
 }
 
-- (double)FirebaseAnalytics_SetUserPropertyString:(NSString *)propertyName value:(NSString *)value {
+- (double)FirebaseAnalytics_SetUserProperty:(NSString *)propertyName value:(NSString *)value {
     if (![self isValidPropertyName:propertyName]) {
         return kFirebaseAnalyticsErrorInvalidParameters;
     }
 
     if ([self isStringNullOrEmpty:value]) {
-        NSLog(@"FirebaseAnalytics_SetUserPropertyString :: property value is empty, clearing property");
+        NSLog(@"FirebaseAnalytics_SetUserProperty :: property value is empty, clearing property");
         value = nil;
     }
     [FIRAnalytics setUserPropertyString:value forName:propertyName];


### PR DESCRIPTION
Resolved a mismatch between the GameMaker extension and the .mm implementation: the extension used FirebaseAnalytics_SetUserProperty, while the native code defined FirebaseAnalytics_SetUserPropertyString, causing the function to not register and throw an exception.